### PR TITLE
Feat/GitHub copilot sdk

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,3 +3,5 @@ OWNER_HANDLE=seldo.com
 NEXT_PUBLIC_OWNER_HANDLE=seldo.com
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
+TWITTER_CONSUMER_KEY=your_twitter_client_id
+TWITTER_SECRET_KEY=your_twitter_client_secret

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,5 @@
 ANTHROPIC_API_KEY=your_api_key_here
 OWNER_HANDLE=seldo.com
 NEXT_PUBLIC_OWNER_HANDLE=seldo.com
+GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_SECRET=your_github_client_secret

--- a/app/api/github/auth/route.ts
+++ b/app/api/github/auth/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+
+export async function GET(request: NextRequest) {
+  const clientId = process.env.GITHUB_CLIENT_ID
+  if (!clientId) {
+    return NextResponse.json({ error: 'GitHub OAuth not configured' }, { status: 500 })
+  }
+
+  const origin = request.nextUrl.searchParams.get('origin') || request.nextUrl.origin
+  const redirectUri = `${origin}/api/github/callback`
+  const state = crypto.randomBytes(16).toString('hex')
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: 'copilot',
+    state,
+  })
+
+  const authUrl = `https://github.com/login/oauth/authorize?${params.toString()}`
+
+  const response = NextResponse.redirect(authUrl)
+
+  response.cookies.set('github_oauth_state', state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 600,
+    path: '/',
+  })
+  response.cookies.set('github_oauth_origin', origin, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 600,
+    path: '/',
+  })
+
+  return response
+}

--- a/app/api/github/callback/route.ts
+++ b/app/api/github/callback/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code')
+  const state = request.nextUrl.searchParams.get('state')
+  const storedState = request.cookies.get('github_oauth_state')?.value
+  const origin = request.cookies.get('github_oauth_origin')?.value || request.nextUrl.origin
+
+  if (!code || !state || state !== storedState) {
+    return NextResponse.redirect(`${origin}/?github_error=invalid_state`)
+  }
+
+  const clientId = process.env.GITHUB_CLIENT_ID
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET
+
+  if (!clientId || !clientSecret) {
+    return NextResponse.redirect(`${origin}/?github_error=not_configured`)
+  }
+
+  try {
+    const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+      }),
+    })
+
+    const tokenData = await tokenRes.json()
+
+    if (tokenData.error) {
+      return NextResponse.redirect(`${origin}/?github_error=${tokenData.error}`)
+    }
+
+    const accessToken = tokenData.access_token
+
+    // Fetch GitHub username
+    const userRes = await fetch('https://api.github.com/user', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+    const userData = await userRes.json()
+
+    const response = NextResponse.redirect(`${origin}/?github_auth=success`)
+
+    response.cookies.set('github_token', accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 8 * 60 * 60, // 8 hours
+      path: '/',
+    })
+    response.cookies.set('github_username', userData.login || '', {
+      httpOnly: false, // readable by client
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 8 * 60 * 60,
+      path: '/',
+    })
+
+    // Clean up OAuth cookies
+    response.cookies.delete('github_oauth_state')
+    response.cookies.delete('github_oauth_origin')
+
+    return response
+  } catch {
+    return NextResponse.redirect(`${origin}/?github_error=token_exchange_failed`)
+  }
+}

--- a/app/api/github/signout/route.ts
+++ b/app/api/github/signout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true })
+  response.cookies.delete('github_token')
+  response.cookies.delete('github_username')
+  return response
+}

--- a/app/api/summarize-github/route.ts
+++ b/app/api/summarize-github/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const githubToken = request.cookies.get('github_token')?.value
+
+  if (!githubToken) {
+    return Response.json({ error: 'Not signed in with GitHub' }, { status: 401 })
+  }
+
+  const { posts, handle, source } = await request.json() as {
+    posts: { text: string; url: string }[]
+    handle: string
+    source?: 'bluesky' | 'twitter'
+  }
+
+  const feedSource = source || 'bluesky'
+
+  if (!Array.isArray(posts) || posts.length === 0) {
+    return Response.json({ error: 'No posts provided' }, { status: 400 })
+  }
+
+  const postsText = posts
+    .slice(0, 2000)
+    .map((p, i) => `[${i + 1}] ${p.text} (${p.url})`)
+    .join('\n\n')
+
+  const prompt = `Below are ${posts.length} posts from my ${feedSource === 'twitter' ? 'Twitter/X' : 'Bluesky'} social feed over the last 24 hours. Each post includes its URL in parentheses. Please summarize what people are talking about.
+
+Organize your response by theme or topic. For each theme, give it a short bold heading, then 2–4 sentences describing what's being discussed and any notable perspectives or debates. Within your summary text, link a few key words or phrases to a representative post URL using markdown links — for example, "[some topic](${feedSource === 'twitter' ? 'https://x.com/...' : 'https://bsky.app/..'})". Pick just one representative post per topic. Do not use footnotes or reference numbers. End with a brief 1–2 sentence "overall vibe" of the feed.
+
+Posts:
+${postsText}`
+
+  try {
+    const res = await fetch('https://api.githubcopilot.com/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${githubToken}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: prompt }],
+        stream: true,
+      }),
+    })
+
+    if (!res.ok) {
+      const err = await res.text()
+      return Response.json(
+        { error: `Copilot API error: ${res.status} — ${err}` },
+        { status: res.status }
+      )
+    }
+
+    const readableStream = new ReadableStream({
+      async start(controller) {
+        const encoder = new TextEncoder()
+        const decoder = new TextDecoder()
+        const reader = res.body!.getReader()
+        let buffer = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() || ''
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue
+            const data = line.slice(6).trim()
+            if (data === '[DONE]') continue
+
+            try {
+              const parsed = JSON.parse(data)
+              const content = parsed.choices?.[0]?.delta?.content
+              if (content) {
+                controller.enqueue(encoder.encode(content))
+              }
+            } catch {
+              // skip malformed chunks
+            }
+          }
+        }
+
+        controller.close()
+      },
+    })
+
+    return new Response(readableStream, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Transfer-Encoding': 'chunked',
+      },
+    })
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return Response.json({ error: msg }, { status: 500 })
+  }
+}

--- a/app/api/twitter/timeline/route.ts
+++ b/app/api/twitter/timeline/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
     const posts: { text: string; url: string }[] = []
     let paginationToken: string | undefined
 
-    while (posts.length < 2000) {
+    while (posts.length < 100) {
       const params = new URLSearchParams({
         max_results: '100',
         'tweet.fields': 'created_at,author_id',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,7 +60,15 @@ export default function Home() {
       // Clean up URL
       window.history.replaceState({}, '', '/')
       setPlatform('twitter')
-      handleTwitterSession()
+      // Auto-detect GitHub Copilot auth so we don't prompt for an Anthropic key
+      const ghUser = document.cookie.split('; ').find(c => c.startsWith('github_username='))?.split('=')[1]
+      let detectedProvider: LlmProvider = 'anthropic'
+      if (ghUser) {
+        setGithubUser(ghUser)
+        setLlmProvider('github-copilot')
+        detectedProvider = 'github-copilot'
+      }
+      handleTwitterSession(detectedProvider)
       return
     }
     if (params.get('twitter_error')) {
@@ -74,7 +82,7 @@ export default function Home() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  async function handleTwitterSession() {
+  async function handleTwitterSession(providerOverride?: LlmProvider) {
     try {
       // Check cache first to avoid unnecessary API calls
       const cached = loadCachedSummary('twitter')
@@ -106,7 +114,7 @@ export default function Home() {
       const twitterHandle = username
       const keyToUse = storedKey || undefined
 
-      await streamSummary(posts, twitterHandle, 'twitter', keyToUse, llmProvider)
+      await streamSummary(posts, twitterHandle, 'twitter', keyToUse, providerOverride ?? llmProvider)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
       setState({ status: 'error', message: msg })
@@ -117,10 +125,15 @@ export default function Home() {
     try {
       const { BrowserOAuthClient } = await import('@atproto/oauth-client-browser')
 
+      // RFC 8252 requires loopback IP (127.0.0.1) instead of "localhost"
+      if (window.location.hostname === 'localhost') {
+        window.location.hostname = '127.0.0.1'
+        return
+      }
+
       const origin = window.location.origin
       const redirectUri = `${origin}/`
-      const isLocalhost = window.location.hostname === 'localhost'
-        || window.location.hostname === '127.0.0.1'
+      const isLocalhost = window.location.hostname === '127.0.0.1'
 
       let clientId: string
 
@@ -193,11 +206,16 @@ export default function Home() {
           }
         }
 
+        // Auto-detect LLM provider based on auth state
+        const hasGithubAuth = !!document.cookie.split('; ').find(c => c.startsWith('github_username='))
+        const detectedProvider: LlmProvider = hasGithubAuth ? 'github-copilot' : 'anthropic'
+        if (hasGithubAuth) setLlmProvider('github-copilot')
+
         const cached = loadCachedSummary('bluesky')
         if (cached && cached.handle === resolvedHandle) {
           setState({ status: 'done', ...cached, platform: 'bluesky' })
         } else {
-          await fetchAndSummarizeBluesky(agent, resolvedHandle, storedKey || undefined)
+          await fetchAndSummarizeBluesky(agent, resolvedHandle, storedKey || undefined, detectedProvider)
         }
       } else {
         const cached = loadCachedSummary('bluesky') || loadCachedSummary('twitter')

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
 
 type Platform = 'bluesky' | 'twitter'
+type LlmProvider = 'anthropic' | 'github-copilot'
 
 type AppState =
   | { status: 'initializing' }
@@ -23,6 +24,8 @@ export default function Home() {
   })
   const [apiKey, setApiKey] = useState('')
   const [platform, setPlatform] = useState<Platform>('bluesky')
+  const [llmProvider, setLlmProvider] = useState<LlmProvider>('anthropic')
+  const [githubUser, setGithubUser] = useState<string | null>(null)
   const clientRef = useRef<import('@atproto/oauth-client-browser').BrowserOAuthClient | null>(null)
   const agentRef = useRef<import('@atproto/api').Agent | null>(null)
 
@@ -30,8 +33,29 @@ export default function Home() {
   const isOwner = handle.trim().replace(/^@/, '') === ownerHandle
 
   useEffect(() => {
+    // Check GitHub username cookie
+    const ghUser = document.cookie.split('; ').find(c => c.startsWith('github_username='))?.split('=')[1]
+    if (ghUser) setGithubUser(ghUser)
+  }, [])
+
+  useEffect(() => {
     // Check for Twitter OAuth callback
     const params = new URLSearchParams(window.location.search)
+    if (params.get('github_auth') === 'success') {
+      window.history.replaceState({}, '', '/')
+      setLlmProvider('github-copilot')
+      const ghUser = document.cookie.split('; ').find(c => c.startsWith('github_username='))?.split('=')[1]
+      if (ghUser) setGithubUser(ghUser)
+      setState({ status: 'login' })
+      initOAuth(true)
+      return
+    }
+    if (params.get('github_error')) {
+      const error = params.get('github_error')!
+      window.history.replaceState({}, '', '/')
+      setState({ status: 'error', message: `GitHub auth failed: ${error}` })
+      return
+    }
     if (params.get('twitter_auth') === 'success') {
       // Clean up URL
       window.history.replaceState({}, '', '/')
@@ -82,7 +106,7 @@ export default function Home() {
       const twitterHandle = username
       const keyToUse = storedKey || undefined
 
-      await streamSummary(posts, twitterHandle, 'twitter', keyToUse)
+      await streamSummary(posts, twitterHandle, 'twitter', keyToUse, llmProvider)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
       setState({ status: 'error', message: msg })
@@ -160,9 +184,13 @@ export default function Home() {
         const isOwnerSession = resolvedHandle === ownerHandle
 
         if (!isOwnerSession && !storedKey) {
-          setState({ status: 'login' })
-          setHandle(resolvedHandle)
-          return
+          // If user has GitHub Copilot auth, they don't need an Anthropic key
+          const hasGithubAuth = !!document.cookie.split('; ').find(c => c.startsWith('github_username='))
+          if (!hasGithubAuth) {
+            setState({ status: 'login' })
+            setHandle(resolvedHandle)
+            return
+          }
         }
 
         const cached = loadCachedSummary('bluesky')
@@ -191,8 +219,10 @@ export default function Home() {
     userHandle: string,
     source: Platform,
     key?: string,
+    provider: LlmProvider = 'anthropic',
   ) {
-    const res = await fetch('/api/summarize', {
+    const endpoint = provider === 'github-copilot' ? '/api/summarize-github' : '/api/summarize'
+    const res = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ posts, handle: userHandle, apiKey: key, source }),
@@ -221,7 +251,8 @@ export default function Home() {
   async function fetchAndSummarizeBluesky(
     agent: import('@atproto/api').Agent,
     userHandle: string,
-    key?: string
+    key?: string,
+    provider: LlmProvider = 'anthropic',
   ) {
     try {
       setState({ status: 'loading', message: 'Fetching your feed...' })
@@ -233,7 +264,7 @@ export default function Home() {
       }
 
       setState({ status: 'loading', message: `Summarizing ${posts.length} posts...` })
-      await streamSummary(posts, userHandle, 'bluesky', key)
+      await streamSummary(posts, userHandle, 'bluesky', key, provider)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
       setState({ status: 'error', message: msg })
@@ -245,15 +276,15 @@ export default function Home() {
     if (!trimmedHandle) return
 
     if (agentRef.current) {
-      if (!isOwner && !apiKey.trim()) return
+      if (!isOwner && llmProvider === 'anthropic' && !apiKey.trim()) return
       if (apiKey.trim()) {
         localStorage.setItem('zeitgeist_api_key', apiKey.trim())
       }
-      await fetchAndSummarizeBluesky(agentRef.current, trimmedHandle, apiKey.trim() || undefined)
+      await fetchAndSummarizeBluesky(agentRef.current, trimmedHandle, apiKey.trim() || undefined, llmProvider)
       return
     }
 
-    if (!isOwner && !apiKey.trim()) return
+    if (!isOwner && llmProvider === 'anthropic' && !apiKey.trim()) return
 
     if (apiKey.trim()) {
       localStorage.setItem('zeitgeist_api_key', apiKey.trim())
@@ -289,7 +320,7 @@ export default function Home() {
       await handleTwitterSession()
     } else {
       if (!agentRef.current) return
-      await fetchAndSummarizeBluesky(agentRef.current, state.handle, storedKey || undefined)
+      await fetchAndSummarizeBluesky(agentRef.current, state.handle, storedKey || undefined, llmProvider)
     }
   }
 
@@ -299,6 +330,10 @@ export default function Home() {
     clientRef.current = null
     // Clear Twitter cookies
     await fetch('/api/twitter/signout', { method: 'POST' }).catch(() => {})
+    // Clear GitHub cookies
+    await fetch('/api/github/signout', { method: 'POST' }).catch(() => {})
+    setGithubUser(null)
+    setLlmProvider('anthropic')
     setState({ status: 'login' })
     setHandle(localStorage.getItem('zeitgeist_bluesky_handle') || '')
     setApiKey('')
@@ -313,7 +348,7 @@ export default function Home() {
     <main className="page">
       <div className="inner">
         <h1 className="siteTitle">Zeitgeist</h1>
-        <p className="siteSubtitle">24-hour feed summary, powered by Claude</p>
+        <p className="siteSubtitle">24-hour feed summary, powered by AI</p>
 
         {state.status === 'initializing' && (
           <div className="loadingWrap">
@@ -358,7 +393,24 @@ export default function Home() {
                     disabled={!!agentRef.current}
                   />
                 </div>
-                {!isOwner && (
+                <div className="formGroup">
+                  <label className="label">LLM Provider</label>
+                  <div className="platformTabs" style={{ marginBottom: '0.5rem' }}>
+                    <button
+                      className={`platformTab ${llmProvider === 'anthropic' ? 'platformTabActive' : ''}`}
+                      onClick={() => setLlmProvider('anthropic')}
+                    >
+                      Anthropic
+                    </button>
+                    <button
+                      className={`platformTab ${llmProvider === 'github-copilot' ? 'platformTabActive' : ''}`}
+                      onClick={() => setLlmProvider('github-copilot')}
+                    >
+                      GitHub Copilot
+                    </button>
+                  </div>
+                </div>
+                {llmProvider === 'anthropic' && !isOwner && (
                   <div className="formGroup">
                     <label className="label" htmlFor="apiKey">
                       Anthropic API key
@@ -381,10 +433,30 @@ export default function Home() {
                     </p>
                   </div>
                 )}
+                {llmProvider === 'github-copilot' && !githubUser && (
+                  <div className="formGroup">
+                    <button
+                      className="btn"
+                      onClick={() => {
+                        window.location.href = `/api/github/auth?origin=${encodeURIComponent(window.location.origin)}`
+                      }}
+                    >
+                      Sign in with GitHub
+                    </button>
+                    <p className="hint" style={{ marginTop: '0.5rem' }}>
+                      Requires a GitHub Copilot subscription. No API key needed.
+                    </p>
+                  </div>
+                )}
+                {llmProvider === 'github-copilot' && githubUser && (
+                  <p className="hint" style={{ marginBottom: '0.5rem' }}>
+                    Signed in to GitHub as <strong>{githubUser}</strong>
+                  </p>
+                )}
                 <button
                   className="btn"
                   onClick={signInBluesky}
-                  disabled={!handle.trim() || (!isOwner && !apiKey.trim())}
+                  disabled={!handle.trim() || (llmProvider === 'anthropic' && !isOwner && !apiKey.trim()) || (llmProvider === 'github-copilot' && !githubUser)}
                 >
                   {agentRef.current ? 'Summarize my feed' : 'Sign in with Bluesky'}
                 </button>
@@ -398,26 +470,65 @@ export default function Home() {
               <>
                 <h2 className="cardTitle">Sign in with Twitter / X</h2>
                 <div className="formGroup">
-                  <label className="label" htmlFor="apiKey">
-                    Anthropic API key
-                  </label>
-                  <input
-                    id="apiKey"
-                    className="input"
-                    type="password"
-                    value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && signInTwitter()}
-                    placeholder="sk-ant-..."
-                  />
-                  <p className="hint" style={{ marginTop: '0.5rem' }}>
-                    Get your API key from{' '}
-                    <a href="https://platform.claude.com/settings/keys" target="_blank" rel="noopener noreferrer">
-                      Anthropic&apos;s console
-                    </a>
-                    . You&apos;ll need an Anthropic account with API credits.
-                  </p>
+                  <label className="label">LLM Provider</label>
+                  <div className="platformTabs" style={{ marginBottom: '0.5rem' }}>
+                    <button
+                      className={`platformTab ${llmProvider === 'anthropic' ? 'platformTabActive' : ''}`}
+                      onClick={() => setLlmProvider('anthropic')}
+                    >
+                      Anthropic
+                    </button>
+                    <button
+                      className={`platformTab ${llmProvider === 'github-copilot' ? 'platformTabActive' : ''}`}
+                      onClick={() => setLlmProvider('github-copilot')}
+                    >
+                      GitHub Copilot
+                    </button>
+                  </div>
                 </div>
+                {llmProvider === 'anthropic' && (
+                  <div className="formGroup">
+                    <label className="label" htmlFor="apiKey">
+                      Anthropic API key
+                    </label>
+                    <input
+                      id="apiKey"
+                      className="input"
+                      type="password"
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && signInTwitter()}
+                      placeholder="sk-ant-..."
+                    />
+                    <p className="hint" style={{ marginTop: '0.5rem' }}>
+                      Get your API key from{' '}
+                      <a href="https://platform.claude.com/settings/keys" target="_blank" rel="noopener noreferrer">
+                        Anthropic&apos;s console
+                      </a>
+                      . You&apos;ll need an Anthropic account with API credits.
+                    </p>
+                  </div>
+                )}
+                {llmProvider === 'github-copilot' && !githubUser && (
+                  <div className="formGroup">
+                    <button
+                      className="btn"
+                      onClick={() => {
+                        window.location.href = `/api/github/auth?origin=${encodeURIComponent(window.location.origin)}`
+                      }}
+                    >
+                      Sign in with GitHub
+                    </button>
+                    <p className="hint" style={{ marginTop: '0.5rem' }}>
+                      Requires a GitHub Copilot subscription. No API key needed.
+                    </p>
+                  </div>
+                )}
+                {llmProvider === 'github-copilot' && githubUser && (
+                  <p className="hint" style={{ marginBottom: '0.5rem' }}>
+                    Signed in to GitHub as <strong>{githubUser}</strong>
+                  </p>
+                )}
                 <button
                   className="btn"
                   onClick={signInTwitter}


### PR DESCRIPTION
**GitHub Copilot integration:**

* Added environment variables for GitHub OAuth and Twitter credentials in `.env.local.example` to enable authentication with external providers.
* Implemented new API routes: `app/api/github/auth/route.ts` for GitHub OAuth initiation, `app/api/github/callback/route.ts` for handling OAuth callback and token exchange, and `app/api/github/signout/route.ts` for signout and cookie cleanup. [[1]](diffhunk://#diff-e8b23fe37c69886cf15348cf8a5804fd2cea96fd7bcb43c0cb624591596f1197R1-R41) [[2]](diffhunk://#diff-965891aceec5b81ce086c4403b63a8c451448097e26552319eb33594ef1ff7d2R1-R73) [[3]](diffhunk://#diff-35317952c33f29f56da514f393d604e71a746a91bce1a23e7b1167a37efcafe5R1-R8)
* Added `app/api/summarize-github/route.ts` to send feed summary requests to GitHub Copilot, streaming results and requiring a valid GitHub token.

**Frontend provider selection and authentication flow:**

* Introduced `llmProvider` state and UI controls in `app/page.tsx` to let users choose between Anthropic and GitHub Copilot, with dynamic display of relevant sign-in fields and buttons. GitHub authentication is handled via OAuth, and user session is tracked with cookies. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R7) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R27-R71) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L361-R431) [[4]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R454-R477)
* Updated summary logic in `app/page.tsx` to auto-detect provider based on authentication state, route summary requests to the correct backend endpoint, and enforce provider-specific requirements (e.g., API key for Anthropic, GitHub login for Copilot). [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L53-R85) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L85-R117) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R200-R218) [[4]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R240-R243) [[5]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L224-R273) [[6]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L236-R285) [[7]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L248-R305) [[8]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L292-R341) [[9]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R351-R354)

**Other updates:**

* Reduced the maximum number of posts fetched from Twitter from 2000 to 100 for savings for testing.
* Updated subtitle in the UI to reflect generic AI provider usage, not just Claude.

These changes collectively enable users to choose between Anthropic and GitHub Copilot for feed summarization, streamline authentication, and ensure the frontend and backend are coordinated for provider-specific flows.